### PR TITLE
Add custom binary location set function (and documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The first argument can be either a file path or an options object. The only requ
 *Custom*
 
 * inputFile - path to the input file.
+* customBin - set a custom path to the AutoTrace binary.
 * binArgs - returns an array of the args to be passed to AutoTrace.
 * debugExec - returns the full exec + args as a string. Useful for debugging.
 

--- a/index.js
+++ b/index.js
@@ -175,6 +175,11 @@ AutoTrace.prototype.binArgs = function() {
 	return [].concat(this.args, this.inputFile);
 };
 
+AutoTrace.prototype.customBin = function(path) {
+	this.bin = path;
+	return this;
+};
+
 AutoTrace.prototype.debugExec = function(value) {
 	if (!!value) console.log(this.bin, this.binArgs().join(' '));
 	return this;


### PR DESCRIPTION
What a handy wrapper! I figured the one thing it needed is the ability to set a custom binary location (as when you're shipping across platforms, you don't always know that autotrace is in the path).